### PR TITLE
feature: connected rate limiting to most critical parts of the app

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
-import {type NextRequest} from 'next/server';
-import {updateSession} from '@/utils/supabase/middleware';
+import { type NextRequest } from 'next/server';
+import { updateSession } from '@/utils/supabase/middleware';
 
 export async function middleware(request: NextRequest) {
   return await updateSession(request);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@radix-ui/react-tabs": "1.1.13",
         "@supabase/ssr": "0.7.0",
         "@supabase/supabase-js": "2.57.2",
+        "@upstash/ratelimit": "2.0.7",
+        "@upstash/redis": "1.36.0",
         "@vercel/speed-insights": "1.3.1",
         "axios": "1.12.1",
         "class-variance-authority": "0.7.1",
@@ -4335,6 +4337,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.7.tgz",
+      "integrity": "sha512-qNQW4uBPKVk8c4wFGj2S/vfKKQxXx1taSJoSGBN36FeiVBBKHQgsjPbKUijZ9Xu5FyVK+pfiXWKIsQGyoje8Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.0.tgz",
+      "integrity": "sha512-9zN2UV9QJGPnXfWU3yZBLVQaqqENDh7g+Y4J2vJuSxBCi9FQ0aUOtaXlzuFhnsiZvCqM+eS27ic+tgmkWUsfOg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/speed-insights": {
       "version": "1.3.1",
@@ -10953,6 +10988,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@radix-ui/react-tabs": "1.1.13",
     "@supabase/ssr": "0.7.0",
     "@supabase/supabase-js": "2.57.2",
+    "@upstash/ratelimit": "2.0.7",
+    "@upstash/redis": "1.36.0",
     "@vercel/speed-insights": "1.3.1",
     "axios": "1.12.1",
     "class-variance-authority": "0.7.1",

--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -1,7 +1,18 @@
 import { NextResponse } from 'next/server';
 import { getChannels } from '@/utils/getChannels';
+import { headers } from 'next/headers';
+import { getFirstIP } from '@/utils/getFirstIp';
+import { rateLimits } from '@/lib/ratelimits';
 
 export async function GET() {
+  const headerList = await headers();
+  const ip = getFirstIP(headerList.get('x-forwarded-for') ?? 'unknown');
+  const { success } = await rateLimits.channelView.limit(ip);
+
+  if (!success) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   try {
     const channels = await getChannels();
 

--- a/src/app/api/search/posts/route.ts
+++ b/src/app/api/search/posts/route.ts
@@ -1,12 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { searchPosts } from '@/lib/search/queries';
+import { rateLimits } from '@/lib/ratelimits';
+import { getFirstIP } from '@/utils/getFirstIp';
 
 export async function GET(request: NextRequest) {
+  const ip = getFirstIP(request.headers.get('x-forwarded-for') ?? 'unknown');
+  const { success } = await rateLimits.search.limit(ip);
+
+  if (!success) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
 
     const query = searchParams.get('q') || '';
-    const limit = Math.min(Math.max(0, parseInt(searchParams.get('limit') || '0')), 100); // Cap limit
+    const limit = Math.min(
+      Math.max(0, parseInt(searchParams.get('limit') || '0')),
+      100
+    );
 
     if (query.length > 100) {
       return NextResponse.json(

--- a/src/features/Mfa/actions/enrollMFA.ts
+++ b/src/features/Mfa/actions/enrollMFA.ts
@@ -1,8 +1,19 @@
 'use server';
 
+import { rateLimits } from '@/lib/ratelimits';
+import { getFirstIP } from '@/utils/getFirstIp';
 import { createClient } from '@/utils/supabase/server';
+import { headers } from 'next/headers';
 
 export async function enrollMFA() {
+  const headerList = await headers();
+  const ip = getFirstIP(headerList.get('x-forwarded-for') ?? 'unknown');
+  const { success } = await rateLimits.mfaSettings.limit(ip);
+
+  if (!success) {
+    throw new Error('Too many requests');
+  }
+
   const supabase = await createClient();
 
   const {

--- a/src/features/Mfa/actions/verifyMFA.ts
+++ b/src/features/Mfa/actions/verifyMFA.ts
@@ -1,6 +1,9 @@
 'use server';
 
+import { rateLimits } from '@/lib/ratelimits';
+import { getFirstIP } from '@/utils/getFirstIp';
 import { createClient } from '@/utils/supabase/server';
+import { headers } from 'next/headers';
 
 export interface VerifyMFAParams {
   factorId: string;
@@ -13,6 +16,14 @@ export async function verifyMFA({
   challengeId,
   code,
 }: VerifyMFAParams) {
+  const headerList = await headers();
+  const ip = getFirstIP(headerList.get('x-forwarded-for') ?? 'unknown');
+  const { success } = await rateLimits.verifyMFA.limit(ip);
+
+  if (!success) {
+    return { success: false, message: 'Too many requests' };
+  }
+
   const supabase = await createClient();
 
   const { error } = await supabase.auth.mfa.verify({

--- a/src/features/PostPollHandler/actions/createPost.ts
+++ b/src/features/PostPollHandler/actions/createPost.ts
@@ -5,6 +5,9 @@ import { posts } from '@/db/schema';
 import { revalidatePath } from 'next/cache';
 import { sanitize, isValidUuid } from '@/lib/security';
 import { getUser } from '@/utils/getUser';
+import { headers } from 'next/headers';
+import { getFirstIP } from '@/utils/getFirstIp';
+import { rateLimits } from '@/lib/ratelimits';
 
 export async function createPostAction(formData: {
   title: string;
@@ -14,6 +17,14 @@ export async function createPostAction(formData: {
   is_anonymous?: boolean;
   is_active?: boolean;
 }) {
+  const headerList = await headers();
+  const ip = getFirstIP(headerList.get('x-forwarded-for') ?? 'unknown');
+  const { success } = await rateLimits.createPost.limit(ip);
+
+  if (!success) {
+    return { success: false, message: 'Too many requests' };
+  }
+
   const user = await getUser();
   const author_id = user?.id;
 

--- a/src/features/postList/actions/handleVote.ts
+++ b/src/features/postList/actions/handleVote.ts
@@ -3,11 +3,22 @@
 import { togglePostReaction } from './postVote';
 import { revalidatePath } from 'next/cache';
 import { getUser } from '@/utils/getUser';
+import { headers } from 'next/headers';
+import { getFirstIP } from '@/utils/getFirstIp';
+import { rateLimits } from '@/lib/ratelimits';
 
 export async function handleVote(
   postId: string,
   reactionType: 'upvote' | 'downvote'
 ) {
+  const headerList = await headers();
+  const ip = getFirstIP(headerList.get('x-forwarded-for') ?? 'unknown');
+  const { success } = await rateLimits.postVote.limit(ip);
+
+  if (!success) {
+    return { success: false, message: 'Too many requests' };
+  }
+
   const user = await getUser();
 
   if (!user || !user.id) {
@@ -18,7 +29,6 @@ export async function handleVote(
 
   const result = await togglePostReaction(postId, user.id, reactionType);
 
-  
   if (result.success) {
     revalidatePath('/posts');
   }

--- a/src/lib/ratelimits.ts
+++ b/src/lib/ratelimits.ts
@@ -1,0 +1,72 @@
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+const redis = Redis.fromEnv();
+
+export const rateLimits = {
+  search: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(10, '1 m'),
+    prefix: 'rl:search',
+  }),
+  login: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(6, '1 m'),
+    prefix: 'rl:login',
+  }),
+  register: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(4, '1 m'),
+    prefix: 'rl:register',
+  }),
+  postView: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(100, '1 m'),
+    prefix: 'rl:post',
+  }),
+  channelView: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(100, '1 m'),
+    prefix: 'rl:channel',
+  }),
+  createChannel: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(1, '1 m'),
+    prefix: 'rl:create-channel',
+  }),
+  createPost: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(2, '1 m'),
+    prefix: 'rl:create-post',
+  }),
+  comment: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(10, '1 m'),
+    prefix: 'rl:comment',
+  }),
+  postVote: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(30, '1 m'),
+    prefix: 'rl:postVote',
+  }),
+  verifyMFA: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(5, '1 m'),
+    prefix: 'rl:verifyMFA',
+  }),
+  mfaSettings: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(1, '1 m'),
+    prefix: 'rl:mfaSettings',
+  }),
+  resetPassword: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(1, '1 m'),
+    prefix: 'rl:resetPassword',
+  }),
+  cspReport: new Ratelimit({
+    redis,
+    limiter: Ratelimit.fixedWindow(60, '1 m'),
+    prefix: 'rl:cspReport',
+  }),
+};

--- a/src/utils/getFirstIp.ts
+++ b/src/utils/getFirstIp.ts
@@ -1,0 +1,4 @@
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#parsing
+export const getFirstIP = (ipList: string) => {
+  return ipList.split(',')[0].trim();
+};


### PR DESCRIPTION
Closes #123 

# Changes

1. Connecte upstash-redis rate limiter
2. Added the rate limiting according to the following table for actions and endpoints

| Functionality/Endpoint | Rate limit | Description |
|--------|--------| --------|
| Search Query | 10 req / 1 minute | Limit the number of search queries made | 
| `\login`  | 4 req / 1 minute |  Number of login attempts made |
| `\register` | 4 req / 1 minute | Number of register attempts made |
| `\post\[id]` | 100 req / 1 minute | Number of get requests for a post - prevents content scraping |
| `\channel\[id]` | 100 req / 1 minute | Number of get requests for a channel - prevents content scraping |
| Creating a channel | 1 req / 1 minute | Number of channels the user can create | 
| Creating a post | 2 req / 1 minute | Number of posts user can make per minute | 
| Commenting on post | 10 req / 1 minute | Number of comments user can write under a post |
| Post vote| 10 req / 1 min| - |
| verifyMFA |5 req / 1 minute| - |
|mfa set up| 1 req / 1 minute| include enroll and unenroll|
|reset password| 1 req/ 1 min| already have on supabase side, but won't be bad to have here|
|csp report|60 req / 1 minute |To not flood the logs|
## Additional Notes

Other endpoints may be covered on demand, error messages will be refined while in review
